### PR TITLE
Updating sbom licensing to Community Specification License 1.0

### DIFF
--- a/process/project-lifecycle-documents/SBOMit_sandbox_stage.md
+++ b/process/project-lifecycle-documents/SBOMit_sandbox_stage.md
@@ -44,8 +44,9 @@ Non-Goals:
 
 When contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
 
+  * See [#191](https://github.com/ossf/tac/issues/191) for LF IP Review
   * Our reference implementations will use the Apache 2.0 license
-  * Our specification uses [Community Specification License 1.0](https://github.com/SBOMit/specification/blob/main/LICENSE.md).
+  * Our specification uses [Community Specification License 1.0](https://github.com/SBOMit/specification/blob/main/LICENSE.md)
   * Our website uses [Creative Commons Attribution 4.0 International](https://github.com/SBOMit/website/blob/main/LICENSE.md)
   
 ### Project References


### PR DESCRIPTION
See issue https://github.com/SBOMit/specification/issues/13.

LF started IP/License review of SBOMit for the OpenSSF sandbox application, and https://github.com/ossf/tac/issues/191#issuecomment-1692546537

See https://github.com/CommunitySpecification/Community_Specification/blob/main/1._Community_Specification_License-v1.md
This is required by the OpenSSF Charter (Section 5, Page 9):
https://cdn.platform.linuxfoundation.org/agreements/openssf.pdf